### PR TITLE
MacOS X EI Capitan下使用此工具遇到错误并简单兼容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.idea/
-/out
+/out/*
 /deploy-passport.sh
 /cert.all.sh

--- a/gen.cert.sh
+++ b/gen.cert.sh
@@ -12,12 +12,24 @@ then
     exit;
 fi
 
+if [ ! -d "./out/newcerts" ]; then
+    mkdir -p "./out/newcerts"
+fi
+
+if [ ! -f "./out/index.txt" ]; then
+    touch "./out/index.txt"
+fi
+
+if [ ! -f "./out/serial" ]; then
+    touch "./out/serial"
+    echo 1000 > ./out/serial
+fi
 SAN=""
 for var in "$@"
 do
     SAN+="DNS:*.${var},DNS:${var},"
 done
-SAN=${SAN: : -1}
+SAN=${SAN:0:${#SAN}-1}
 
 # Move to root directory
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -53,4 +65,4 @@ ln -snf "../cert.key.pem" "${BASE_DIR}/$1.key.pem"
 # Output certifications
 echo
 echo "Certifications are located in:"
-ls -la --color `pwd`/${BASE_DIR}/*.*
+ls -la `pwd`/${BASE_DIR}/*.*

--- a/gen.root.sh
+++ b/gen.root.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+folder="./out"
+if [ ! -d "$folder" ]; then
+    mkdir "$folder"
+fi
+
 # Generate root cert along with root key
 openssl req -config ca.cnf \
     -newkey rsa:2048 -nodes -keyout out/root.key.pem \


### PR DESCRIPTION
主要遇到下面两个问题：
1、目录&文件不存在的问题
2、Bash命令不支持的问题

第一个问题在gen.root.sh中会第一次出现，因为out目录不存在，紧接着是gen.cert.sh中out的子目录newerts不存在，然后文件(./out/index.txt和./out/serial)同样在首次运行gen.cert.sh会提示不存在的报错。
第二个问题出现在两个地方：字符串(SAN)截取不支持负数参数和ls命令没有--color参数的支持

以上就是我在本机遇到的问题，希望该项目越来越好！